### PR TITLE
Dockerfile tweaks, mostly to reduce size of the resulting image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,55 +7,30 @@ MAINTAINER The ThreatHunting Project <project@threathunting.net>
 # Set user to run these commands as root
 USER root
 
-# Update the list of packages so we can install what we need
-RUN apt-get update --yes && apt-get clean
-
 # Switch back to the jovyan user to do module installs or this will fail
 # due to directory ownership on the cache
 USER $NB_USER
 
-# Update anaconda to latest version
-RUN conda update -y -n base conda
-
-# Create the Python 2.7 environment
-RUN conda create --name python2 python=2
+# Update anaconda to latest version, create a python2 environment
+RUN conda update -y -n base conda && conda create --name python2 python=2
 
 # Install the Python 2.x kernel
 RUN /opt/conda/envs/python2/bin/pip install ipykernel && /opt/conda/envs/python2/bin/python -m ipykernel install --user
 
-# Install the standard Jupyter notebook extensions
-RUN conda install jupyter_contrib_nbextensions
+# Install Python packages.
+ENV INSTALL_PACKAGES_CONDA plotly elasticsearch-dsl seaborn scikit-learn
+ENv INSTALL_PACKAGES_PIP splunk-sdk featuretools
 
-# Install data analysis modules. For python3, these are installed by default
-# so we just make sure they are the latest versions.
-RUN conda upgrade -y seaborn matplotlib pandas numpy scikit-learn
-RUN conda install -y --name python2 seaborn matplotlib pandas numpy scikit-learn
-
-# Install Plot.ly for most visualization needs
-RUN conda install -y plotly
-RUN conda install -y --name python2 plotly
-
-# Elasticsearch client for Python.  The DSL (high level) version also installs
-# the standard elasticsearch-py library as a dependency, so it's available
-# even though we don't explicity install it here.
-RUN conda install -y  elasticsearch-dsl
-RUN conda install -y --name python2  elasticsearch-dsl
-
-# Grab the Splunk SDK as well.  Note that this seems to only support
-# python2.  Also, it's not in the conda channel, so we have to use
-# pip.
-RUN /opt/conda/envs/python2/bin/pip install splunk-sdk
-
-# Install featuretools module, for automatic feature extraction in datasets
-RUN pip install featuretools
-RUN /opt/conda/envs/python2/bin/pip install featuretools
+RUN conda install -y jupyter_contrib_nbextensions ${INSTALL_PACKAGES_CONDA} && \
+    conda install -y --name python2 ${INSTALL_PACKAGES_CONDA} && \
+    pip install ${INSTALL_PACKAGES_PIP} && \
+    /opt/conda/envs/python2/bin/pip install ${INSTALL_PACKAGES_PIP}
 
 # The first time you 'import plotly' on a new system, it has to build the
 # font cache.  This takes a while and also causes spurious warnings, so
 # we can just do that during the build process and the user never has to
 # see it.
-RUN /opt/conda/bin/python -c 'import plotly'
-RUN /opt/conda/envs/python2/bin/python -c 'import plotly'
+RUN /opt/conda/bin/python -c 'import plotly' && /opt/conda/envs/python2/bin/python -c 'import plotly'
 
 # Set the notebook default password
 ADD passwd-helper.py /tmp


### PR DESCRIPTION
* Combined similar RUN statements into groups
* Parameterized the conda and pip installs by using environment variables to hold the list of packages.
  This avoids having to type the same list of packages for both python3 and python2 install commands.
* Removed useless 'apt-get update && apt-get clean' command since we don't mess with OS packages
* No longer explicitly update python packages already present in the upstream image. They're pretty up-to-date already.